### PR TITLE
fix(redirects): send tools.oxlo.ai traffic to www.oxcode.ai

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const OXCODE = "https://www.oxcode.ai";
+
 const nextConfig: NextConfig = {
   reactCompiler: true,
   // Proxy tier2 streaming tool requests directly to the Python runner,
@@ -11,6 +13,15 @@ const nextConfig: NextConfig = {
         source: "/api/tools-stream/:toolId",
         destination: `${runnerUrl}/api/tools/:toolId`,
       },
+    ];
+  },
+  async redirects() {
+    return [
+      // Root needs its own rule: the catch-all param below cannot match an empty path.
+      { source: "/", destination: OXCODE, permanent: false },
+      // api/ is excluded because redirects run before rewrites — catching it
+      // would disable the tool route handler and the streaming proxy above.
+      { source: "/:path((?!api/).*)", destination: OXCODE, permanent: false },
     ];
   },
 };


### PR DESCRIPTION
## Problem

tools.oxlo.ai still serves the Oxlo tools playground. All Oxlo traffic should land on www.oxcode.ai.

## Solution

Catch-all 307 added alongside the existing `rewrites()` in `app/next.config.ts`. The rewrites block is unchanged.

`/api/` is excluded on purpose. Next evaluates `redirects()` before `rewrites()`, so a blanket catch-all would swallow both the `/api/tools/[toolId]` route handler and the `/api/tools-stream/:toolId` proxy to the Python runner — every tool run would break, including the long-lived streaming path that proxy exists to protect.

No logged-in exemption here, unlike the portal PR. Nothing on Oxtools needs one — key rotation and billing live on the portal, which keeps its own.

Temporary 307, not permanent, so it can be reverted without anyone's browser having cached it.

## Testing

Local dev server, asserting status code and `Location` header:

- `/`, `/tools`, `/tools/[id]` — all 307 to https://www.oxcode.ai/
- `/api/tools/x` — still 405, not redirected
- `/api/tools-stream/x` — still 500 with `ECONNREFUSED :9080`, not redirected. That error is the point: the proxy is still firing and trying to reach the runner, which isn't running locally. A redirect here instead would mean the rewrite had been swallowed.

`npm run build` passes.

Note on lint: `npm run lint` fails on this branch, but it fails identically on `dev`. `biome.json` sets `useIgnoreFile: false`, so it lints `.next/` — 59 source files plus 629 build files is where the huge diagnostic count comes from. `next.config.ts` was already non-conforming before this change too (repo uses spaces, biome is configured for tabs). Left it alone rather than reformatting the file and burying an 11-line change under a full-file diff. Happy to do that separately if you'd rather.
